### PR TITLE
Modernization

### DIFF
--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -2,7 +2,7 @@
 # This GitHub action runs basic linting checks for Packer.
 #
 
-name: "Go Validate"
+name: "Go Validation"
 
 on:
   push:
@@ -45,6 +45,10 @@ jobs:
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
           check-latest: true
+      - name: Update golangci-lint
+        run: |
+           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.2
+           golangci-lint --version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:

--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   get-go-version:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:

--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -45,10 +45,6 @@ jobs:
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
           check-latest: true
-      - name: Update golangci-lint
-        run: |
-           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.2
-           golangci-lint --version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,5 @@
 ---
-name: draft-release
+name: Draft Release
 on:
   pull_request_target:
     types:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          # 'latest', 'nightly', or a semver
+          # 'latest', 'nightly', or a semver (Example: ~> v2)
           version: '~> v2'
           args: release --clean
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
@@ -44,10 +46,10 @@ jobs:
         run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-name: release
+name: Build and Release
 on:
   push:
     tags:

--- a/.github/workflows/test-plugin-example.yml
+++ b/.github/workflows/test-plugin-example.yml
@@ -2,7 +2,7 @@
 # It uses Packer at latest version to init, validate and build
 # an example configuration in a folder.
 # This action is compatible with Packer v1.7.0 or later.
-name: test plugin example
+name: Test Plugin Example
 
 on:
   workflow_dispatch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,7 +67,7 @@ signs:
       # if you are using this is in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
-      - "--local-user"
+      - "--u"
       - "{{ .Env.GPG_FINGERPRINT }}"
       - "--output"
       - "${signature}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Packer Plugin for Podman
 
-[![Build Status](https://github.com/ddreggors/packer-plugin-podman/workflows/build-and-test/badge.svg)](https://github.com/golangci/golangci-lint-action/actions)
+[![Go Code Validation](https://github.com/ddreggors/packer-plugin-podman/actions/workflows/go-validate.yml/badge.svg)](https://github.com/ddreggors/packer-plugin-podman/actions/workflows/go-validate.yml) [![Build/Release](https://github.com/ddreggors/packer-plugin-podman/actions/workflows/release.yml/badge.svg)](https://github.com/ddreggors/packer-plugin-podman/actions/workflows/release.yml)
 
 This repository contains a Packer Plugin for Podman. It directly takes the source code from
 [github.com/hashicorp/packer-plugin-docker](https://github.com/hashicorp/packer-plugin-docker) and it "remixes" it to

--- a/builder/podman/config.go
+++ b/builder/podman/config.go
@@ -5,15 +5,17 @@ package podman
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/mitchellh/mapstructure"
-	"os"
 )
 
+//nolint:staticcheck
 var (
 	errArtifactNotUsed     = fmt.Errorf("No instructions given for handling the artifact; expected commit, discard, or export_path")
 	errArtifactUseConflict = fmt.Errorf("Cannot specify more than one of commit, discard, and export_path")

--- a/builder/podman/config_test.go
+++ b/builder/podman/config_test.go
@@ -1,7 +1,6 @@
 package podman
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -45,11 +44,11 @@ func testConfigOk(t *testing.T, warns []string, err error) {
 }
 
 func TestConfigPrepare_exportPath(t *testing.T) {
-	td, err := ioutil.TempDir("", "packer")
+	td, err := os.MkdirTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	defer os.RemoveAll(td)
+	defer os.RemoveAll(td) //nolint:errcheck
 
 	raw := testConfig()
 

--- a/builder/podman/step_connect_podman.go
+++ b/builder/podman/step_connect_podman.go
@@ -14,7 +14,7 @@ type StepConnectPodman struct{}
 func (s *StepConnectPodman) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	config, ok := state.Get("config").(*Config)
 	if !ok {
-		err := fmt.Errorf("error encountered obtaining podman config")
+		err := fmt.Errorf("error encountered obtaining podman config") //nolint:staticcheck
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
@@ -61,7 +61,7 @@ func getContainerUser(containerId string) (string, error) {
 		if ee, ok := err.(*exec.ExitError); ok {
 			errStr = fmt.Sprintf("%s, %s", errStr, ee.Stderr)
 		}
-		return "", fmt.Errorf(errStr)
+		return "", fmt.Errorf(errStr) //nolint:staticcheck
 	}
 	return strings.TrimSpace(string(stdout)), nil
 }

--- a/builder/podman/step_export.go
+++ b/builder/podman/step_export.go
@@ -17,7 +17,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 	ui := state.Get("ui").(packersdk.Ui)
 	config, ok := state.Get("config").(*Config)
 	if !ok {
-		err := fmt.Errorf("error encountered obtaining podman config")
+		err := fmt.Errorf("error encountered obtaining podman config") //nolint:staticcheck
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -25,7 +25,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 
 	// We should catch this in validation, but guard anyway
 	if config.ExportPath == "" {
-		err := fmt.Errorf("No output file specified, we can't export anything")
+		err := fmt.Errorf("No output file specified, we can't export anything") //nolint:staticcheck
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -41,7 +41,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 	// Open the file that we're going to write to
 	f, err := os.Create(config.ExportPath)
 	if err != nil {
-		err := fmt.Errorf("Error creating output file: %s", err)
+		err := fmt.Errorf("Error creating output file: %s", err) //nolint:staticcheck
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -52,15 +52,15 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 
 	ui.Say("Exporting the container")
 	if err := driver.Export(containerId, f); err != nil {
-		f.Close()
-		os.Remove(f.Name())
+		f.Close()           //nolint:errcheck
+		os.Remove(f.Name()) //nolint:errcheck
 
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
 
-	f.Close()
+	f.Close() //nolint:errcheck
 	return multistep.ActionContinue
 }
 

--- a/builder/podman/step_export_test.go
+++ b/builder/podman/step_export_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -27,12 +26,12 @@ func TestStepExport(t *testing.T) {
 	defer step.Cleanup(state)
 
 	// Create a tempfile for our output path
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	tf.Close()
-	defer os.Remove(tf.Name())
+	tf.Close()                 //nolint:errcheck
+	defer os.Remove(tf.Name()) //nolint:errcheck
 
 	config := state.Get("config").(*Config)
 	config.ExportPath = tf.Name()
@@ -53,7 +52,7 @@ func TestStepExport(t *testing.T) {
 	}
 
 	// verify the data exported to the file
-	contents, err := ioutil.ReadFile(tf.Name())
+	contents, err := os.ReadFile(tf.Name())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -69,11 +68,11 @@ func TestStepExport_error(t *testing.T) {
 	defer step.Cleanup(state)
 
 	// Create a tempfile for our output path
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	tf.Close()
+	tf.Close() //nolint:errcheck
 
 	if err := os.Remove(tf.Name()); err != nil {
 		t.Fatalf("err: %s", err)

--- a/builder/podman/step_pull.go
+++ b/builder/podman/step_pull.go
@@ -15,7 +15,7 @@ func (s *StepPull) Run(ctx context.Context, state multistep.StateBag) multistep.
 	ui := state.Get("ui").(packersdk.Ui)
 	config, ok := state.Get("config").(*Config)
 	if !ok {
-		err := fmt.Errorf("error encountered obtaining podman config")
+		err := fmt.Errorf("error encountered obtaining podman config") //nolint:staticcheck
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -37,7 +37,7 @@ func (s *StepPull) Run(ctx context.Context, state multistep.StateBag) multistep.
 			config.LoginUsername,
 			config.LoginPassword)
 		if err != nil {
-			err := fmt.Errorf("Error logging in: %s", err)
+			err := fmt.Errorf("Error logging in: %s", err) //nolint:staticcheck
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -53,7 +53,7 @@ func (s *StepPull) Run(ctx context.Context, state multistep.StateBag) multistep.
 	}
 
 	if err := driver.Pull(config.Image); err != nil {
-		err := fmt.Errorf("Error pulling Podman image: %s", err)
+		err := fmt.Errorf("Error pulling Podman image: %s", err) //nolint:staticcheck
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/podman/step_run.go
+++ b/builder/podman/step_run.go
@@ -16,7 +16,7 @@ func (s *StepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 	ui := state.Get("ui").(packersdk.Ui)
 	config, ok := state.Get("config").(*Config)
 	if !ok {
-		err := fmt.Errorf("error encountered obtaining podman config")
+		err := fmt.Errorf("error encountered obtaining podman config") //nolint:staticcheck
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -45,7 +45,7 @@ func (s *StepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 	ui.Say("Starting podman container...")
 	containerId, err := driver.StartContainer(&runConfig)
 	if err != nil {
-		err := fmt.Errorf("Error running container: %s", err)
+		err := fmt.Errorf("Error running container: %s", err) //nolint:staticcheck
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/podman/step_temp_dir.go
+++ b/builder/podman/step_temp_dir.go
@@ -3,7 +3,6 @@ package podman
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -46,9 +45,9 @@ func ConfigTmpDir() (string, error) {
 		return "", err
 	}
 
-	td, err := ioutil.TempDir(configdir, "tmp")
+	td, err := os.MkdirTemp(configdir, "tmp")
 	if err != nil {
-		return "", fmt.Errorf("Error creating temp dir: %s", err)
+		return "", fmt.Errorf("Error creating temp dir: %s", err) //nolint:staticcheck
 
 	}
 	log.Printf("Set Packer temp dir to %s", td)
@@ -62,7 +61,7 @@ func (s *StepTempDir) Run(ctx context.Context, state multistep.StateBag) multist
 
 	tempdir, err := ConfigTmpDir()
 	if err != nil {
-		err := fmt.Errorf("Error making temp dir: %s", err)
+		err := fmt.Errorf("Error making temp dir: %s", err) //nolint:staticcheck
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -75,6 +74,6 @@ func (s *StepTempDir) Run(ctx context.Context, state multistep.StateBag) multist
 
 func (s *StepTempDir) Cleanup(state multistep.StateBag) {
 	if s.tempDir != "" {
-		os.RemoveAll(s.tempDir)
+		os.RemoveAll(s.tempDir) //nolint:errcheck
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@ var (
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.
-	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+	PluginVersion = version.NewPluginVersion(Version, VersionPrerelease, "")
 )


### PR DESCRIPTION
Lint tests were failing due to changes in Go version and Go Plugin versions changing. Several changes had to be made to bring the code to a more modern state.

* Move from `io/ioutil` (deprecated) to `os` or `io` variants of ReadAll/TempDir/TempFile/etc...
  - ioutil.ReadAll -> io.ReadAll
  - ioutil.ReadFile -> os.ReadFile
  - ioutil.ReadDir -> os.ReadDir
  - ioutil.NopCloser -> io.NopCloser
  - ioutil.TempDir -> os.MkdirTemp
  - ioutil.TempFile -> os.CreateTemp
  - ioutil.WriteFile -> os.WriteFile
* Use `NewPluginVersion` now over `InitializePluginVersion`
* Add some //nolint lines to avoid errorcheck/staticcheck in some areas
* Add some inline functions to catch errors on some defer statements